### PR TITLE
Fix build on iOS example

### DIFF
--- a/examples/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/examples/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 		3ACD21341EAE60D2000D1DED /* AAPLAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AAPLAppDelegate.m; sourceTree = "<group>"; };
 		907FE32A28789CDAFD777257 /* SampleCode.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = SampleCode.xcconfig; path = Configuration/SampleCode.xcconfig; sourceTree = "<group>"; };
 		C40DE48F2C7BDC6E00031804 /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; path = assets; sourceTree = "<group>"; };
-		C4623DBD2C6D8856000C2843 /* WgpuApp.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WgpuApp.xcframework; path = ../iOS/build/XCFrameworks/release/WgpuApp.xcframework; sourceTree = "<group>"; };
+		C4623DBD2C6D8856000C2843 /* WgpuApp.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WgpuApp.xcframework; path = ../iOS/build/XCFrameworks/release/WgpuApp.xcframework; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */


### PR DESCRIPTION
Changed the sourceTree property of WgpuApp.xcframework from "<group>" to "SOURCE_ROOT" in the project.pbxproj file. This ensures the framework's path is resolved relative to the project root, improving clarity and consistency.