### PR TITLE
Replace bitflag enum instances with PascalCase values.

### DIFF
--- a/generator/src/main/kotlin/YamlParser.kt
+++ b/generator/src/main/kotlin/YamlParser.kt
@@ -1,8 +1,10 @@
 import com.charleskorn.kaml.Yaml
 import domain.YamlModel
+import generator.bitflagCommonMainFile
 import generator.enumerationCommonMainFile
 import generator.enumerationNativeMainFile
 import generator.enumerationWebMainFile
+import generator.generateCommonBitflag
 import generator.generateCommonEnumerations
 import generator.generateNativeEnumerations
 import generator.generateWebEnumerations
@@ -16,6 +18,8 @@ fun main() {
     enumerationCommonMainFile.generateCommonEnumerations(webgpuModel.enums)
     enumerationWebMainFile.generateWebEnumerations(webgpuModel.enums)
     enumerationNativeMainFile.generateNativeEnumerations(webgpuModel.enums)
+
+    bitflagCommonMainFile.generateCommonBitflag(webgpuModel.bitflags)
 }
 
 fun loadExtraYaml() = readFileFromClasspath("extra.yml")

--- a/generator/src/main/kotlin/generator/BitflagGenerator.kt
+++ b/generator/src/main/kotlin/generator/BitflagGenerator.kt
@@ -1,0 +1,27 @@
+package generator
+
+import Paths
+import disclamer
+import domain.YamlModel
+import generator.bitflag.toBitflagEnumerations
+import java.io.File
+
+val bitflagCommonMainFile = Paths.commonMain
+    .resolve("bitflag.enumerations.kt")
+
+
+private val header = """
+    $disclamer
+    package io.ygdrasil.webgpu
+    
+    
+""".trimIndent()
+
+internal fun File.generateCommonBitflag(enumerations: List<YamlModel.Bitflag>) {
+
+    writeText(header)
+
+    enumerations.toBitflagEnumerations()
+        .let(::appendText)
+
+}

--- a/generator/src/main/kotlin/generator/bitflag/common.template.kt
+++ b/generator/src/main/kotlin/generator/bitflag/common.template.kt
@@ -1,0 +1,29 @@
+package generator.bitflag
+
+import builder.templateBuilder
+import convertToKotlinClassName
+import domain.YamlModel
+
+
+private fun indexToFlagValue(base: Int): Int = if (base == 0) 0 else 1 shl (base - 1)
+
+fun List<YamlModel.Bitflag>.toBitflagEnumerations() = templateBuilder {
+    forEach { bitflag ->
+        val name = bitflag.name.convertToKotlinClassName()
+        appendBlock("enum class $name(override val value: Int, override val uValue: UInt): EnumerationWithValue") {
+            bitflag.entries
+                .forEachIndexed { index, entry ->
+                    // Calculate first if that a combination
+                    val value = entry.value_combination?.sumOf { subPart -> indexToFlagValue(bitflag.entries.indexOfFirst { it.name == subPart }) }
+                        ?: indexToFlagValue(index)
+
+                    val name = entry.name.convertToKotlinClassName()
+                    appendLine("$name($value, ${value}u),")
+                }
+        }
+    }
+}
+
+internal fun String.convertToEnumValueName() = split("_")
+    .map { component -> component.replaceFirstChar { it.uppercase() } }
+    .joinToString("")

--- a/wgpu4k-scenes/src/commonMain/kotlin/Application.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/Application.kt
@@ -88,7 +88,7 @@ private fun WGPUContext.configureRenderingContext() {
         SurfaceConfiguration(
             device = device,
             format = format,
-            usage = setOf(TextureUsage.renderAttachment, TextureUsage.copySrc),
+            usage = setOf(TextureUsage.RenderAttachment, TextureUsage.CopySrc),
             alphaMode = alphaMode
         )
     )

--- a/wgpu4k-scenes/src/commonMain/kotlin/Scene.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/Scene.kt
@@ -48,7 +48,7 @@ suspend fun loadScenes(wgpuContext: WGPUContext, resourceBasePath: String = ""):
             TextureDescriptor(
                 size = Size3D(1u, 1u),
                 format = TextureFormat.Depth24Plus,
-                usage = setOf(TextureUsage.renderAttachment),
+                usage = setOf(TextureUsage.RenderAttachment),
             )
         ).also { with(autoClosableContext) { it.bind() } }
     }

--- a/wgpu4k-scenes/src/commonMain/kotlin/headless/render.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/headless/render.kt
@@ -37,7 +37,7 @@ suspend fun captureScene() {
             val outputStagingBuffer = context.device.createBuffer(
                 BufferDescriptor(
                     size = (textureData.size * Int.SIZE_BYTES).toULong(),
-                    usage = setOf(BufferUsage.copydst, BufferUsage.mapread),
+                    usage = setOf(BufferUsage.CopyDst, BufferUsage.MapRead),
                     mappedAtCreation = false,
                 )
             )
@@ -69,7 +69,7 @@ suspend fun captureScene() {
                 )
 
                 context.device.queue.submit(listOf(commandEncoder.finish()))
-                outputStagingBuffer.map(setOf(MapMode.read))
+                outputStagingBuffer.map(setOf(MapMode.Read))
                 // Complete async work
                 context.device.poll()
                 outputStagingBuffer.mapInto(buffer = textureData)

--- a/wgpu4k-scenes/src/commonMain/kotlin/helper/glb/domain.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/helper/glb/domain.kt
@@ -4,7 +4,10 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ygdrasil.webgpu.AddressMode
 import io.ygdrasil.webgpu.BindGroup
 import io.ygdrasil.webgpu.BindGroupDescriptor
-import io.ygdrasil.webgpu.BindGroupDescriptor.*
+import io.ygdrasil.webgpu.BindGroupDescriptor.BindGroupEntry
+import io.ygdrasil.webgpu.BindGroupDescriptor.BufferBinding
+import io.ygdrasil.webgpu.BindGroupDescriptor.SamplerBinding
+import io.ygdrasil.webgpu.BindGroupDescriptor.TextureViewBinding
 import io.ygdrasil.webgpu.BindGroupLayout
 import io.ygdrasil.webgpu.BindGroupLayoutDescriptor
 import io.ygdrasil.webgpu.BindGroupLayoutDescriptor.Entry
@@ -224,7 +227,7 @@ class GLTFMaterial(material: GLTF2.Material? = null, textures: List<GLTFTexture>
         val buf = device.createBuffer(
             BufferDescriptor(
                 size = 3uL * 4uL * 4uL,
-                setOf(BufferUsage.uniform),
+                setOf(BufferUsage.Uniform),
                 mappedAtCreation = true
             )
         )
@@ -236,7 +239,7 @@ class GLTFMaterial(material: GLTF2.Material? = null, textures: List<GLTFTexture>
         val layoutEntries = mutableListOf(
             Entry(
                 binding = 0u,
-                visibility = setOf(ShaderStage.fragment),
+                visibility = setOf(ShaderStage.Fragment),
                 bindingType = BufferBindingLayout(
                     type = BufferBindingType.Uniform
                 ),
@@ -255,14 +258,14 @@ class GLTFMaterial(material: GLTF2.Material? = null, textures: List<GLTFTexture>
             layoutEntries.add(
                 Entry(
                     binding = 1u,
-                    visibility = setOf(ShaderStage.fragment),
+                    visibility = setOf(ShaderStage.Fragment),
                     bindingType = SamplerBindingLayout(),
                 )
             )
             layoutEntries.add(
                 Entry(
                     binding = 2u,
-                    visibility = setOf(ShaderStage.fragment),
+                    visibility = setOf(ShaderStage.Fragment),
                     bindingType = Entry.TextureBindingLayout(),
                 )
             )
@@ -383,7 +386,7 @@ class GLTFNode(val name: String, val mesh: GLTFMesh, val transform: FloatArray) 
         gpuUniforms = device.createBuffer(
             BufferDescriptor(
                 size = 4uL * 4uL * 4uL,
-                usage = setOf(BufferUsage.uniform),
+                usage = setOf(BufferUsage.Uniform),
                 mappedAtCreation = true
             )
         )
@@ -404,7 +407,7 @@ class GLTFNode(val name: String, val mesh: GLTFMesh, val transform: FloatArray) 
                 entries = listOf(
                     Entry(
                         binding = 0u,
-                        visibility = setOf(ShaderStage.vertex),
+                        visibility = setOf(ShaderStage.Vertex),
                         bindingType = BufferBindingLayout(type = BufferBindingType.Uniform)
                     )
                 )

--- a/wgpu4k-scenes/src/commonMain/kotlin/helper/glb/import.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/helper/glb/import.kt
@@ -44,7 +44,7 @@ suspend fun uploadGLBModel(
             TextureDescriptor(
                 size = Size3D(width = bitmap.width.toUInt(), height = bitmap.height.toUInt(), depthOrArrayLayers = 1u),
                 format = textureFormat,
-                usage = setOf(TextureUsage.textureBinding, TextureUsage.copyDst, TextureUsage.renderAttachment)
+                usage = setOf(TextureUsage.TextureBinding, TextureUsage.CopyDst, TextureUsage.RenderAttachment)
             )
         )
 
@@ -90,7 +90,7 @@ suspend fun uploadGLBModel(
                     val accessor = gltf2.accessors[primitive.indices]
                     val viewID = accessor.bufferView
                     bufferViews[viewID].needsUpload = true
-                    bufferViews[viewID].addUsage(BufferUsage.index)
+                    bufferViews[viewID].addUsage(BufferUsage.Index)
                     GLTFAccessor(bufferViews[viewID], accessor)
                 } else null
 
@@ -101,7 +101,7 @@ suspend fun uploadGLBModel(
                     val accessor = gltf2.accessors[index]
                     val viewID = accessor.bufferView
                     bufferViews[viewID].needsUpload = true
-                    bufferViews[viewID].addUsage(BufferUsage.vertex)
+                    bufferViews[viewID].addUsage(BufferUsage.Vertex)
                     when (attribute.str) {
                         "POSITION" -> positions = GLTFAccessor(bufferViews[viewID], accessor)
                         "NORMAL" -> normals = GLTFAccessor(bufferViews[viewID], accessor)

--- a/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/Cubemap.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/Cubemap.kt
@@ -61,7 +61,7 @@ class CubemapScene(wgpuContext: WGPUContext, assetManager: AssetManager) : Scene
 		verticesBuffer = device.createBuffer(
 			BufferDescriptor(
 				size = (cubeVertexArray.size * Float.SIZE_BYTES).toULong(),
-				usage = setOf(BufferUsage.vertex),
+				usage = setOf(BufferUsage.Vertex),
 				mappedAtCreation = true
 			)
 		)
@@ -124,7 +124,7 @@ class CubemapScene(wgpuContext: WGPUContext, assetManager: AssetManager) : Scene
 			TextureDescriptor(
 				size = Size3D(renderingContext.width, renderingContext.height),
 				format = TextureFormat.Depth24Plus,
-				usage = setOf(TextureUsage.renderAttachment),
+				usage = setOf(TextureUsage.RenderAttachment),
 			)
 		).bind()
 
@@ -143,7 +143,7 @@ class CubemapScene(wgpuContext: WGPUContext, assetManager: AssetManager) : Scene
 				// Assume each image has the same size.
 				size = Size3D(imageBitmaps[0].width, imageBitmaps[0].height, depthLayer),
 				format = renderingContext.textureFormat,
-				usage = setOf(TextureUsage.textureBinding, TextureUsage.copyDst, TextureUsage.renderAttachment),
+				usage = setOf(TextureUsage.TextureBinding, TextureUsage.CopyDst, TextureUsage.RenderAttachment),
 			)
 		).bind()
 
@@ -159,7 +159,7 @@ class CubemapScene(wgpuContext: WGPUContext, assetManager: AssetManager) : Scene
 		uniformBuffer = device.createBuffer(
 			BufferDescriptor(
 				size = uniformBufferSize,
-				usage = setOf(BufferUsage.uniform, BufferUsage.copydst)
+				usage = setOf(BufferUsage.Uniform, BufferUsage.CopyDst)
 			)
 		).bind()
 

--- a/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/FractalCube.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/FractalCube.kt
@@ -56,7 +56,7 @@ class FractalCubeScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
 		verticesBuffer = device.createBuffer(
 			BufferDescriptor(
 				size = (cubeVertexArray.size * Float.SIZE_BYTES).toULong(),
-				usage = setOf(BufferUsage.vertex),
+				usage = setOf(BufferUsage.Vertex),
 				mappedAtCreation = true
 			)
 		)
@@ -119,7 +119,7 @@ class FractalCubeScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
 			TextureDescriptor(
 				size = Size3D(renderingContext.width, renderingContext.height),
 				format = TextureFormat.Depth24Plus,
-				usage = setOf(TextureUsage.renderAttachment),
+				usage = setOf(TextureUsage.RenderAttachment),
 			)
 		).bind()
 
@@ -127,7 +127,7 @@ class FractalCubeScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
 		uniformBuffer = device.createBuffer(
 			BufferDescriptor(
 				size = uniformBufferSize,
-				usage = setOf(BufferUsage.uniform, BufferUsage.copydst)
+				usage = setOf(BufferUsage.Uniform, BufferUsage.CopyDst)
 			)
 		).bind()
 
@@ -137,7 +137,7 @@ class FractalCubeScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
 			TextureDescriptor(
 				size = Size3D(renderingContext.width, renderingContext.height),
 				format = renderingContext.textureFormat,
-				usage = setOf(TextureUsage.textureBinding, TextureUsage.copyDst),
+				usage = setOf(TextureUsage.TextureBinding, TextureUsage.CopyDst),
 			)
 		)
 

--- a/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/HelloTriangleMSAA.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/HelloTriangleMSAA.kt
@@ -61,7 +61,7 @@ class HelloTriangleMSAAScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
                 size = Size3D(renderingContext.width, renderingContext.height),
                 sampleCount = sampleCount,
                 format = renderingContext.textureFormat,
-                usage = setOf(TextureUsage.renderAttachment),
+                usage = setOf(TextureUsage.RenderAttachment),
             )
         ).bind()
         textureView = texture.createView().bind()

--- a/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/HelloTriangleRotating.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/HelloTriangleRotating.kt
@@ -56,7 +56,7 @@ class HelloTriangleRotatingScene(wgpuContext: WGPUContext) : Scene(wgpuContext) 
         uniformBuffer = device.createBuffer(
             BufferDescriptor(
                 size = uniformBufferSize,
-                usage = setOf(BufferUsage.uniform, BufferUsage.copydst)
+                usage = setOf(BufferUsage.Uniform, BufferUsage.CopyDst)
             )
         ).bind()
 

--- a/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/InstancedCube.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/InstancedCube.kt
@@ -52,7 +52,7 @@ class InstancedCubeScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
 		verticesBuffer = device.createBuffer(
 			BufferDescriptor(
 				size = (Cube.cubeVertexArray.size * Float.SIZE_BYTES).toULong(),
-				usage = setOf(BufferUsage.vertex),
+				usage = setOf(BufferUsage.Vertex),
 				mappedAtCreation = true
 			)
 		)
@@ -115,7 +115,7 @@ class InstancedCubeScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
 			TextureDescriptor(
 				size = Size3D(renderingContext.width, renderingContext.height),
 				format = TextureFormat.Depth24Plus,
-				usage = setOf(TextureUsage.renderAttachment),
+				usage = setOf(TextureUsage.RenderAttachment),
 			)
 		).bind()
 
@@ -123,7 +123,7 @@ class InstancedCubeScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
 		uniformBuffer = device.createBuffer(
 			BufferDescriptor(
 				size = uniformBufferSize,
-				usage = setOf(BufferUsage.uniform, BufferUsage.copydst)
+				usage = setOf(BufferUsage.Uniform, BufferUsage.CopyDst)
 			)
 		).bind()
 

--- a/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/RotatingCube.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/RotatingCube.kt
@@ -50,7 +50,7 @@ class RotatingCubeScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
 		verticesBuffer = device.createBuffer(
 			BufferDescriptor(
 				size = (cubeVertexArray.size * Float.SIZE_BYTES).toULong(),
-				usage = setOf(BufferUsage.vertex),
+				usage = setOf(BufferUsage.Vertex),
 				mappedAtCreation = true
 			)
 		).bind()
@@ -117,7 +117,7 @@ class RotatingCubeScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
 			TextureDescriptor(
 				size = Size3D(renderingContext.width, renderingContext.height),
 				format = TextureFormat.Depth24Plus,
-				usage = setOf(TextureUsage.renderAttachment),
+				usage = setOf(TextureUsage.RenderAttachment),
 			)
 		).bind()
 
@@ -125,7 +125,7 @@ class RotatingCubeScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
 		uniformBuffer = device.createBuffer(
 			BufferDescriptor(
 				size = uniformBufferSize,
-				usage = setOf(BufferUsage.uniform, BufferUsage.copydst)
+				usage = setOf(BufferUsage.Uniform, BufferUsage.CopyDst)
 			)
 		).bind()
 

--- a/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/TexturedCube.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/TexturedCube.kt
@@ -51,7 +51,7 @@ class TexturedCubeScene(wgpuContext: WGPUContext, assetManager: AssetManager) : 
         verticesBuffer = device.createBuffer(
             BufferDescriptor(
                 size = (Cube.cubeVertexArray.size * Float.SIZE_BYTES).toULong(),
-                usage = setOf(BufferUsage.vertex),
+                usage = setOf(BufferUsage.Vertex),
                 mappedAtCreation = true
             )
         )
@@ -114,7 +114,7 @@ class TexturedCubeScene(wgpuContext: WGPUContext, assetManager: AssetManager) : 
             TextureDescriptor(
                 size = Size3D(renderingContext.width, renderingContext.height),
                 format = TextureFormat.Depth24Plus,
-                usage = setOf(TextureUsage.renderAttachment),
+                usage = setOf(TextureUsage.RenderAttachment),
             )
         ).bind()
 
@@ -122,7 +122,7 @@ class TexturedCubeScene(wgpuContext: WGPUContext, assetManager: AssetManager) : 
         uniformBuffer = device.createBuffer(
             BufferDescriptor(
                 size = uniformBufferSize,
-                usage = setOf(BufferUsage.uniform, BufferUsage.copydst)
+                usage = setOf(BufferUsage.Uniform, BufferUsage.CopyDst)
             )
         ).bind()
 
@@ -134,7 +134,7 @@ class TexturedCubeScene(wgpuContext: WGPUContext, assetManager: AssetManager) : 
             TextureDescriptor(
                 size = Size3D(imageBitmapWidth, imageBitmapHeight),
                 format = renderingContext.textureFormat,
-                usage = setOf(TextureUsage.textureBinding, TextureUsage.copyDst, TextureUsage.renderAttachment),
+                usage = setOf(TextureUsage.TextureBinding, TextureUsage.CopyDst, TextureUsage.RenderAttachment),
             )
         )
 

--- a/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/TwoCubes.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/TwoCubes.kt
@@ -54,7 +54,7 @@ class TwoCubesScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
 		verticesBuffer = device.createBuffer(
 			BufferDescriptor(
 				size = (cubeVertexArray.size * Float.SIZE_BYTES).toULong(),
-				usage = setOf(BufferUsage.vertex),
+				usage = setOf(BufferUsage.Vertex),
 				mappedAtCreation = true
 			)
 		).bind()
@@ -117,7 +117,7 @@ class TwoCubesScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
 			TextureDescriptor(
 				size = Size3D(renderingContext.width, renderingContext.height),
 				format = TextureFormat.Depth24Plus,
-				usage = setOf(TextureUsage.renderAttachment),
+				usage = setOf(TextureUsage.RenderAttachment),
 			)
 		).bind()
 
@@ -126,7 +126,7 @@ class TwoCubesScene(wgpuContext: WGPUContext) : Scene(wgpuContext) {
 		uniformBuffer = device.createBuffer(
 			BufferDescriptor(
 				size = uniformBufferSize,
-				usage = setOf(BufferUsage.uniform, BufferUsage.copydst)
+				usage = setOf(BufferUsage.Uniform, BufferUsage.CopyDst)
 			)
 		).bind()
 

--- a/wgpu4k-scenes/src/commonMain/kotlin/scenes/graphics.techniques/Particles.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/scenes/graphics.techniques/Particles.kt
@@ -76,7 +76,7 @@ class ParticlesScene(wgpuContext: WGPUContext, assetManager: AssetManager) : Sce
         particlesBuffer = device.createBuffer(
             BufferDescriptor(
                 size = (numParticles * particleInstanceByteSize).toULong(),
-                usage = setOf(BufferUsage.vertex, BufferUsage.storage),
+                usage = setOf(BufferUsage.Vertex, BufferUsage.Storage),
             )
         ).bind()
 
@@ -166,7 +166,7 @@ class ParticlesScene(wgpuContext: WGPUContext, assetManager: AssetManager) : Sce
             TextureDescriptor(
                 size = Size3D(renderingContext.width, renderingContext.height),
                 format = TextureFormat.Depth24Plus,
-                usage = setOf(TextureUsage.renderAttachment),
+                usage = setOf(TextureUsage.RenderAttachment),
             )
         )
 
@@ -179,7 +179,7 @@ class ParticlesScene(wgpuContext: WGPUContext, assetManager: AssetManager) : Sce
         uniformBuffer = device.createBuffer(
             BufferDescriptor(
                 size = uniformBufferSize.toULong(),
-                usage = setOf(BufferUsage.uniform, BufferUsage.copydst),
+                usage = setOf(BufferUsage.Uniform, BufferUsage.CopyDst),
             )
         ).bind()
 
@@ -221,7 +221,7 @@ class ParticlesScene(wgpuContext: WGPUContext, assetManager: AssetManager) : Sce
         quadVertexBuffer = device.createBuffer(
             BufferDescriptor(
                 size = 6u * 2u * 4u, // 6x vec2f
-                usage = setOf(BufferUsage.vertex),
+                usage = setOf(BufferUsage.Vertex),
                 mappedAtCreation = true,
             )
         )
@@ -257,10 +257,10 @@ class ParticlesScene(wgpuContext: WGPUContext, assetManager: AssetManager) : Sce
                 format = TextureFormat.RGBA8Unorm,
                 usage =
                 setOf(
-                    TextureUsage.textureBinding,
-                    TextureUsage.storageBinding,
-                    TextureUsage.copyDst,
-                    TextureUsage.renderAttachment
+                    TextureUsage.TextureBinding,
+                    TextureUsage.StorageBinding,
+                    TextureUsage.CopyDst,
+                    TextureUsage.RenderAttachment
                 ),
             )
         )
@@ -303,19 +303,19 @@ class ParticlesScene(wgpuContext: WGPUContext, assetManager: AssetManager) : Sce
         val probabilityMapUBOBuffer = device.createBuffer(
             BufferDescriptor(
                 size = probabilityMapUBOBufferSize.toULong(),
-                usage = setOf(BufferUsage.uniform, BufferUsage.copydst),
+                usage = setOf(BufferUsage.Uniform, BufferUsage.CopyDst),
             )
         )
         val buffer_a = device.createBuffer(
             BufferDescriptor(
                 size = textureWidth * textureHeight * 4uL,
-                usage = setOf(BufferUsage.storage),
+                usage = setOf(BufferUsage.Storage),
             )
         )
         val buffer_b = device.createBuffer(
             BufferDescriptor(
                 size = textureWidth * textureHeight * 4uL,
-                usage = setOf(BufferUsage.storage),
+                usage = setOf(BufferUsage.Storage),
             )
         )
         device.queue.writeBuffer(
@@ -394,7 +394,7 @@ class ParticlesScene(wgpuContext: WGPUContext, assetManager: AssetManager) : Sce
         simulationUBOBuffer = device.createBuffer(
             BufferDescriptor(
                 size = simulationUBOBufferSize.toULong(),
-                usage = setOf(BufferUsage.uniform, BufferUsage.copydst),
+                usage = setOf(BufferUsage.Uniform, BufferUsage.CopyDst),
             )
         )
 

--- a/wgpu4k-scenes/src/commonMain/kotlin/scenes/graphics.techniques/SkinnedMesh.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/scenes/graphics.techniques/SkinnedMesh.kt
@@ -53,7 +53,7 @@ class SkinnedMeshScene(wgpuContext: WGPUContext, assetManager: AssetManager) : S
                     depthOrArrayLayers = 1u
                 ),
                 format = TextureFormat.Depth24PlusStencil8,
-                usage = setOf(TextureUsage.renderAttachment)
+                usage = setOf(TextureUsage.RenderAttachment)
             )
         ).bind()
 
@@ -82,7 +82,7 @@ class SkinnedMeshScene(wgpuContext: WGPUContext, assetManager: AssetManager) : S
                 entries = listOf(
                     Entry(
                         binding = 0u,
-                        visibility = setOf(ShaderStage.vertex),
+                        visibility = setOf(ShaderStage.Vertex),
                         bindingType = Entry.BufferBindingLayout(type = BufferBindingType.Uniform)
                     )
                 )
@@ -91,7 +91,7 @@ class SkinnedMeshScene(wgpuContext: WGPUContext, assetManager: AssetManager) : S
 
         viewParamBuf = device.createBuffer(
             BufferDescriptor(
-                size = 4uL * 4uL * 4uL, usage = setOf(BufferUsage.uniform, BufferUsage.copydst)
+                size = 4uL * 4uL * 4uL, usage = setOf(BufferUsage.Uniform, BufferUsage.CopyDst)
             )
         ).bind()
 

--- a/wgpu4k-toolkit/src/commonMain/kotlin/TextureRenderingContext.kt
+++ b/wgpu4k-toolkit/src/commonMain/kotlin/TextureRenderingContext.kt
@@ -15,7 +15,7 @@ class TextureRenderingContext(
                 label = "render texture",
                 size = Size3D(256u, 256u),
                 format = textureFormat,
-                usage = setOf(TextureUsage.renderAttachment, TextureUsage.copySrc, TextureUsage.copyDst)
+                usage = setOf(TextureUsage.RenderAttachment, TextureUsage.CopySrc, TextureUsage.CopyDst)
             )
         )
     }

--- a/wgpu4k/src/commonMain/kotlin/Enumerations.kt
+++ b/wgpu4k/src/commonMain/kotlin/Enumerations.kt
@@ -3,7 +3,6 @@ package io.ygdrasil.webgpu
 interface EnumerationWithValue {
     val value: Int
     val uValue: UInt
-        get() = value.toUInt()
 
     infix fun or(other: Int): Int = value or other
     infix fun or(other: EnumerationWithValue): Int = value or other.value
@@ -19,12 +18,6 @@ internal fun Set<EnumerationWithValue>.toFlagUInt(): UInt = when (size) {
     0 -> 0u
     1 -> first().value.toUInt()
     else -> fold(0u) { acc, enumerationWithValue -> acc or enumerationWithValue.value.toUInt() }
-}
-
-internal fun Set<EnumerationWithValue>.toFlagULong(): ULong = when (size) {
-    0 -> 0u
-    1 -> first().value.toULong()
-    else -> fold(0u) { acc, enumerationWithValue -> acc or enumerationWithValue.value.toULong() }
 }
 
 enum class SurfaceTextureStatus(
@@ -52,87 +45,7 @@ enum class SurfaceTextureStatus(
     }
 }
 
-enum class BufferUsage(
-    override val value: Int,
-) : EnumerationWithValue {
-    mapread(1),
-    mapwrite(2),
-    copysrc(4),
-    copydst(8),
-    index(16),
-    vertex(32),
-    uniform(64),
-    storage(128),
-    indirect(256),
-    queryresolve(512);
 
-    companion object {
-        fun of(value: Int): BufferUsage? = entries.find {
-            it.value == value
-        }
-    }
-}
-
-enum class ColorWriteMask(
-    override val value: Int,
-) : EnumerationWithValue {
-    none(0),
-    red(1),
-    green(2),
-    blue(4),
-    alpha(8),
-    all(15);
-
-    companion object {
-        fun of(value: Int): ColorWriteMask? = entries.find {
-            it.value == value
-        }
-    }
-}
-
-enum class MapMode(
-    override val value: Int,
-) : EnumerationWithValue {
-    read(1),
-    write(2);
-
-    companion object {
-        fun of(value: Int): MapMode? = entries.find {
-            it.value == value
-        }
-    }
-}
-
-enum class ShaderStage(
-    override val value: Int,
-) : EnumerationWithValue {
-    vertex(1),
-    fragment(2),
-    compute(4);
-
-    companion object {
-        fun of(value: Int): ShaderStage? = entries.find {
-            it.value == value
-        }
-    }
-}
-
-enum class TextureUsage(
-    override val value: Int,
-) : EnumerationWithValue {
-    none(0),
-    copySrc(1),
-    copyDst(2),
-    textureBinding(4),
-    storageBinding(8),
-    renderAttachment(16);
-
-    companion object {
-        fun of(value: Int): TextureUsage? = entries.find {
-            it.value == value
-        }
-    }
-}
 
 infix fun Int.or(other: TextureUsage): Int = this or other.value
 

--- a/wgpu4k/src/commonMain/kotlin/Pipeline.kt
+++ b/wgpu4k/src/commonMain/kotlin/Pipeline.kt
@@ -89,7 +89,7 @@ data class RenderPipelineDescriptor(
 
         data class ColorTargetState(
             val format: TextureFormat,
-            val writeMask: ColorWriteMask = ColorWriteMask.all,
+            val writeMask: ColorWriteMask = ColorWriteMask.All,
             val blend: BlendState = BlendState(),
         ) {
             data class BlendState(

--- a/wgpu4k/src/commonMain/kotlin/Surface.kt
+++ b/wgpu4k/src/commonMain/kotlin/Surface.kt
@@ -3,7 +3,7 @@ package io.ygdrasil.webgpu
 data class SurfaceConfiguration(
     val device: Device,
     val format: TextureFormat,
-    val usage: Set<TextureUsage> = setOf(TextureUsage.renderAttachment),
+    val usage: Set<TextureUsage> = setOf(TextureUsage.RenderAttachment),
     val viewFormats: Set<TextureFormat> = setOf(),
     val colorSpace: PredefinedColorSpace = PredefinedColorSpace.srgb,
     val alphaMode: CompositeAlphaMode = CompositeAlphaMode.Opaque,

--- a/wgpu4k/src/commonMain/kotlin/bitflag.enumerations.kt
+++ b/wgpu4k/src/commonMain/kotlin/bitflag.enumerations.kt
@@ -1,0 +1,43 @@
+// This file has been generated DO NOT EDIT !!!
+package io.ygdrasil.webgpu
+
+enum class BufferUsage(override val value: Int, override val uValue: UInt): EnumerationWithValue {
+	None(0, 0u),
+	MapRead(1, 1u),
+	MapWrite(2, 2u),
+	CopySrc(4, 4u),
+	CopyDst(8, 8u),
+	Index(16, 16u),
+	Vertex(32, 32u),
+	Uniform(64, 64u),
+	Storage(128, 128u),
+	Indirect(256, 256u),
+	QueryResolve(512, 512u),
+}
+enum class ColorWriteMask(override val value: Int, override val uValue: UInt): EnumerationWithValue {
+	None(0, 0u),
+	Red(1, 1u),
+	Green(2, 2u),
+	Blue(4, 4u),
+	Alpha(8, 8u),
+	All(15, 15u),
+}
+enum class MapMode(override val value: Int, override val uValue: UInt): EnumerationWithValue {
+	None(0, 0u),
+	Read(1, 1u),
+	Write(2, 2u),
+}
+enum class ShaderStage(override val value: Int, override val uValue: UInt): EnumerationWithValue {
+	None(0, 0u),
+	Vertex(1, 1u),
+	Fragment(2, 2u),
+	Compute(4, 4u),
+}
+enum class TextureUsage(override val value: Int, override val uValue: UInt): EnumerationWithValue {
+	None(0, 0u),
+	CopySrc(1, 1u),
+	CopyDst(2, 2u),
+	TextureBinding(4, 4u),
+	StorageBinding(8, 8u),
+	RenderAttachment(16, 16u),
+}

--- a/wgpu4k/src/commonTest/kotlin/Enumerations.kt
+++ b/wgpu4k/src/commonTest/kotlin/Enumerations.kt
@@ -19,25 +19,25 @@ class EnumerationsTest : FreeSpec({
 
     "test flag to int with one flag" {
         // Given
-        val withFlags = setOf(BufferUsage.vertex)
+        val withFlags = setOf(BufferUsage.Vertex)
 
         // When
         val intFlag = withFlags.toFlagInt()
 
         // Then
 
-        intFlag shouldBe BufferUsage.vertex.value
+        intFlag shouldBe BufferUsage.Vertex.value
     }
 
     "test flag to int with multiple flags" {
         // Given
-        val withFlags = setOf(BufferUsage.vertex, BufferUsage.copydst, BufferUsage.uniform)
+        val withFlags = setOf(BufferUsage.Vertex, BufferUsage.CopyDst, BufferUsage.Uniform)
 
         // When
         val intFlag = withFlags.toFlagInt()
 
         // Then
 
-        intFlag shouldBe (BufferUsage.vertex.value or BufferUsage.copydst.value or BufferUsage.uniform.value)
+        intFlag shouldBe (BufferUsage.Vertex.value or BufferUsage.CopyDst.value or BufferUsage.Uniform.value)
     }
 })


### PR DESCRIPTION
Updated various instances of enum usage to comply with PascalCase naming convention. This ensures consistency across codebase and aligns with the naming style used in the auto-generated enumerations.