### PR TITLE
Fix enum bit shift values and replace logback dependency by SLF4J for Android.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ coroutines = "1.9.0"
 korge = "6.0.0"
 agp = "8.5.2"
 rococoa = "0.0.1"
+slf4j-simple = "2.0.16"
 wgpu4k-native = "v22.0.1"
 android-native-helper = "0.0.1"
 glfw-native = "0.0.1"
@@ -35,6 +36,7 @@ ktor-server-netty-jvm = { module = "io.ktor:ktor-server-netty-jvm", version.ref 
 ktor-server-core-jvm = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
 playwright = { module = "com.microsoft.playwright:playwright", version.ref = "playwright" }
 rococoa = { module = "io.ygdrasil:rococoa", version.ref = "rococoa" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j-simple" }
 wgpu4k-native = { module = "io.ygdrasil:wgpu4k-native", version.ref = "wgpu4k-native" }
 wgpu-specs = { module = "io.ygdrasil:wgpu4k-native-specs-jvm", version.ref = "wgpu4k-native" }
 glfw-native = { module = "io.ygdrasil:glfw-native", version.ref = "glfw-native" }

--- a/wgpu4k/build.gradle.kts
+++ b/wgpu4k/build.gradle.kts
@@ -122,10 +122,20 @@ kotlin {
             dependencies {
                 implementation(libs.coroutines)
                 api(libs.kotlin.logging)
+            }
+        }
+
+        jvmMain {
+            dependencies {
                 implementation(libs.logback)
             }
         }
 
+        if (isAndroidConfigured) androidMain {
+            dependencies {
+                implementation(libs.slf4j.simple)
+            }
+        }
 
         val commonNativeMain by getting {
             dependencies { api(libs.wgpu4k.native) }

--- a/wgpu4k/src/commonNativeMain/kotlin/WGPU.kt
+++ b/wgpu4k/src/commonNativeMain/kotlin/WGPU.kt
@@ -147,12 +147,12 @@ class WGPU(private val handler: WGPUInstance) : AutoCloseable {
 
 enum class WGPUInstanceBackend(val value: Int) {
 
-    Vulkan(1 shl 1),
-    GL(1 shl 5),
+    Vulkan(1 shl 0),
+    GL(1 shl 1),
     Metal(1 shl 2),
     DX12(1 shl 3),
     DX11(1 shl 4),
-    BrowserWebGPU(1 shl 6),
+    BrowserWebGPU(1 shl 5),
     Primary(Vulkan.value or Metal.value or DX12.value or BrowserWebGPU.value),
     Secondary(GL.value or DX11.value),
     None(0x00000000);


### PR DESCRIPTION
Corrected incorrect bit shift values in the `WGPUInstanceBackend` enum to align with expected behavior. Added the `slf4j-simple` dependency for the Android platform and updated the `libs.versions.toml` file to include its version details.