### PR TITLE
Fix CanvasSurface height calculation in WebMain

### DIFF
--- a/wgpu4k/src/commonWebMain/kotlin/CanvasSurface.kt
+++ b/wgpu4k/src/commonWebMain/kotlin/CanvasSurface.kt
@@ -8,7 +8,7 @@ class CanvasSurface(private val handler: GPUCanvasContext) {
     val width: UInt
         get() = map(handler.canvas.width)
     val height: UInt
-        get() = map(handler.canvas.width)
+        get() = map(handler.canvas.height)
 
     val preferredCanvasFormat: TextureFormat?
         get() = navigator.gpu


### PR DESCRIPTION
The height property was incorrectly mapping the canvas width instead of the canvas height. This change corrects the mapping to ensure proper functionality and alignment with expected behavior.