### PR TITLE
Add support for optional buffer label in descriptors

### DIFF
--- a/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/HelloTriangleRotating.kt
+++ b/wgpu4k-scenes/src/commonMain/kotlin/scenes/basic/HelloTriangleRotating.kt
@@ -55,6 +55,7 @@ class HelloTriangleRotatingScene(wgpuContext: WGPUContext) : Scene(wgpuContext) 
         val uniformBufferSize = 4uL * 16uL // 4x4 matrix
         uniformBuffer = device.createBuffer(
             BufferDescriptor(
+                label = "Uniform Buffer",
                 size = uniformBufferSize,
                 usage = setOf(BufferUsage.Uniform, BufferUsage.CopyDst)
             )

--- a/wgpu4k/src/commonNativeMain/kotlin/mapper/BufferDescriptor.kt
+++ b/wgpu4k/src/commonNativeMain/kotlin/mapper/BufferDescriptor.kt
@@ -6,6 +6,7 @@ import io.ygdrasil.webgpu.toFlagUInt
 import io.ygdrasil.wgpu.WGPUBufferDescriptor
 
 internal fun MemoryAllocator.map(input: BufferDescriptor) = WGPUBufferDescriptor.allocate(this).also { output ->
+    if (input.label != null) output.label = allocateFrom(input.label)
     output.size = input.size
     output.usage = input.usage.toFlagUInt()
     output.mappedAtCreation = input.mappedAtCreation


### PR DESCRIPTION
This update enables assigning labels to buffer descriptors to enhance debugging and clarity. It also includes an example of labeling a uniform buffer in the HelloTriangleRotating scene.