### PR TITLE
Update wgpu4k-native version to v24.0.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ android-native-helper = "0.0.1"
 glfw-native = "0.0.1"
 
 # WebGPU
-wgpu4k-native = "v24.0.1"
+wgpu4k-native = "v24.0.2"
 webgpu-ktypes = "0.0.1"
 
 # Logging


### PR DESCRIPTION
Bump the wgpu4k-native dependency from v24.0.1 to v24.0.2 in the versions file. This keeps the project dependencies up to date and may include bug fixes or minor improvements.