### PR TITLE
Automatically download JDK

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,9 @@ pluginManagement {
 		maven("https://s01.oss.sonatype.org/content/repositories/snapshots")
 	}
 }
+plugins {
+	id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+}
 
 dependencyResolutionManagement {
 	repositories {


### PR DESCRIPTION
When cloning this repository, it did not build for me because I was missing the correct JDK.
This change makes the correct JDK be downloaded automatically. 