### PR TITLE
Prevent texture destruction for canvas-based surfaces

### DIFF
--- a/wgpu4k-toolkit/src/commonWebMain/kotlin/Surface.kt
+++ b/wgpu4k-toolkit/src/commonWebMain/kotlin/Surface.kt
@@ -14,7 +14,7 @@ actual class Surface(private val handler: WGPUCanvasContext) : AutoCloseable {
 
     actual fun getCurrentTexture(): SurfaceTexture {
         return handler.getCurrentTexture()
-            .let(::Texture)
+            .let { Texture(it, canBeDestroy = false)}
             .let { SurfaceTexture(it, SurfaceTextureStatus.success) }
     }
 

--- a/wgpu4k/src/commonWebMain/kotlin/CanvasSurface.kt
+++ b/wgpu4k/src/commonWebMain/kotlin/CanvasSurface.kt
@@ -15,7 +15,7 @@ class CanvasSurface(val handler: WGPUCanvasContext) {
 
     fun getCurrentTexture(): SurfaceTexture {
         return handler.getCurrentTexture()
-            .let { Texture(it) }
+            .let { Texture(it, canBeDestroy = false) }
             .let { SurfaceTexture(it, SurfaceTextureStatus.success) }
     }
 

--- a/wgpu4k/src/commonWebMain/kotlin/Texture.kt
+++ b/wgpu4k/src/commonWebMain/kotlin/Texture.kt
@@ -2,7 +2,7 @@ package io.ygdrasil.webgpu
 
 import io.ygdrasil.webgpu.mapper.map
 
-actual class Texture(val handler: WGPUTexture) : GPUTexture {
+actual class Texture(val handler: WGPUTexture, val canBeDestroy: Boolean = true) : GPUTexture {
 
     actual override var label: String
         get() = handler.label
@@ -34,6 +34,7 @@ actual class Texture(val handler: WGPUTexture) : GPUTexture {
     }
 
     actual override fun close() {
-        handler.destroy()
+        // On firefox, canvas textures throw an exception when calling destroy
+        if (canBeDestroy) handler.destroy()
     }
 }


### PR DESCRIPTION
Introduced a `canBeDestroy` flag to the `Texture` class to avoid calling `destroy` on canvas textures, which causes exceptions in Firefox. Updated related methods in `Surface` and `CanvasSurface` to use this flag.