### PR TITLE
Upgrade wgpu4k-native to v25

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ android-native-helper = "0.0.1"
 glfw-native = "0.0.1"
 
 # WebGPU
-wgpu4k-native = "v24.0.3"
+wgpu4k-native = "v25.0.2"
 webgpu-ktypes = "0.0.7"
 
 # Logging


### PR DESCRIPTION
Updated the wgpu4k-native dependency from v24.0.3 to v25.0.1 in the build configuration. This upgrade brings compatibility improvements and ensures the project uses the latest version of the library.