### PR TITLE
Update webgpu-ktypes to version 0.0.7

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ glfw-native = "0.0.1"
 
 # WebGPU
 wgpu4k-native = "v24.0.3"
-webgpu-ktypes = "0.0.6"
+webgpu-ktypes = "0.0.7"
 
 # Logging
 kotlin-logging = "7.0.7"


### PR DESCRIPTION
This upgrade ensures compatibility with the latest features and bug fixes offered by the library. No other dependencies were modified in this commit.